### PR TITLE
Add options to customize queries globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Set these properties within `cloak: { craft: { ... } }` in the nuxt.config.js:
 - `site` - The Craft CMS Site handle to restrict queries to.  If populated, it gets automatically passed into all GraphQL queries as a variable called `site`.  Defaults to `process.env.CMS_SITE`.
 - `pageTypenames` - An array of GraphQL typenames of Craft entry types whose URIs should be generated as pages.  For example: `['towers_tower_Entry']`.  Defaults to `[]`.
 - `generateRedirects` - If true, adds redirect to the `static/_redirects` file using a `redirects` Craft section.
+- `payloadTransformers` - An array of `addPayloadTransformer` callbacks (see below)
 - `mocks` - An array of objects for use with [`mockAxiosGql`](https://github.com/BKWLD/cloak-utils/blob/main/src/axios.js).
 - `injectClient` - Boolean for whether to inject the `$craft` client globally.  Defaults to `true`.  You would set this to `false` when this module is a depedency of another module (like [@cloak-app/algolia](https://github.com/BKWLD/cloak-algolia)) that is creating `$craft` a different way.
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The [`craft-client` Nuxt plugin](./plugins/craft-client.js) injects `$craft` glo
 - `$craft.getEntries({ query, variables })` - Sugar for `$craft.execute()` that returns the `entries` property of the GraphQL response.
 - `$craft.getEntry({ query, variables })` - Sugar for `$craft.execute()` that returns the `entry` property of the GraphQL response.
 - `$craft.setSite(site)` - Updates the `site` variable for all future requests at runtime.
+- `$craft.addPayloadTransformer(callback)` - Adds a transforming callback. A callback has a type of `({ query: string, variables?: object}) => { query: string, variables?: object}`.  Example: `$craft.addPayloadTransformer((payload) => payload.variables.category = 'pants')`.
 
 ```coffee
 # A page component

--- a/factories/craft-client-factory.js
+++ b/factories/craft-client-factory.js
@@ -1,10 +1,12 @@
 import pickBy from 'lodash/pickBy'
 
 // Factory method for making Craft Axios clients
-export default function (axios, { endpoint, site, query } = {}) {
+export default function (axios, {
+	endpoint, site, query, payloadTransformers
+} = {}) {
 
-	// Store custom transformers
-	const payloadTransformers = []
+	// Make empty array if not defined
+	if (!payloadTransformers) payloadTransformers = []
 
 	// Make Craft instance
 	const craft = axios.create({

--- a/factories/craft-client-factory.js
+++ b/factories/craft-client-factory.js
@@ -3,6 +3,9 @@ import pickBy from 'lodash/pickBy'
 // Factory method for making Craft Axios clients
 export default function (axios, { endpoint, site, query } = {}) {
 
+	// Store custom transformers
+	const payloadTransformers = []
+
 	// Make Craft instance
 	const craft = axios.create({
 		baseURL: endpoint,
@@ -14,9 +17,12 @@ export default function (axios, { endpoint, site, query } = {}) {
 	// Add execute helper for running gql queries
 	craft.execute = async payload => {
 
-		// Massage the request
+		// Transform the request
 		payload = cleanEmptyArrays(payload)
 		payload = restrictToSite(payload, site)
+		payloadTransformers.forEach(transformer => {
+			payload = transformer(payload)
+		})
 
 		// Execute the query
 		const response = await craft({
@@ -46,6 +52,11 @@ export default function (axios, { endpoint, site, query } = {}) {
 
 	// Update the site variable
 	craft.setSite = (newSite) => site = newSite
+
+	// Add custom payload transformer
+	craft.addPayloadTransformer = (callback) => {
+		payloadTransformers.push(callback)
+	}
 
 	// Return the client
 	return craft

--- a/nuxt.js
+++ b/nuxt.js
@@ -21,7 +21,6 @@ export default function() {
 	setPublicDefaultOptions(this, 'craft', {
 		endpoint: process.env.CMS_ENDPOINT,
 		site: process.env.CMS_SITE,
-		payloadTransformers: [],
 		mocks: [],
 	})
 
@@ -44,7 +43,9 @@ export default function() {
 	requireOnce(this, join(__dirname, './modules/mock-craft.js'))
 
 	// Statically generate dynamic pages
-	requireOnce(this, join(__dirname, './modules/generate-pages.js'))
+	if (this.options.cloak.craft.generatePages) {
+		requireOnce(this, join(__dirname, './modules/generate-pages.js'))
+	}
 
 	// Generate Netlify redirects
 	if (process.env.NETLIFY && this.options.cloak.craft.generateRedirects) {

--- a/nuxt.js
+++ b/nuxt.js
@@ -21,6 +21,7 @@ export default function() {
 	setPublicDefaultOptions(this, 'craft', {
 		endpoint: process.env.CMS_ENDPOINT,
 		site: process.env.CMS_SITE,
+		payloadTransformers: [],
 		mocks: [],
 	})
 

--- a/nuxt.js
+++ b/nuxt.js
@@ -13,6 +13,7 @@ export default function() {
 	// Set default non-exposed options
 	setDefaultOptions(this, 'craft', {
 		generateRedirects: false,
+		generatePages: true,
 		pageTypenames: [],
 		injectClient: true,
 	})

--- a/yarn.lock
+++ b/yarn.lock
@@ -10664,7 +10664,7 @@ webpack-dev-middleware@^4.2.0:
     range-parser "^1.2.1"
     schema-utils "^3.0.0"
 
-"webpack-graphql-loader@github:gpoitch/graphql-loader#gp/refresh", webpack-graphql-loader@gpoitch/graphql-loader#gp/refresh:
+webpack-graphql-loader@gpoitch/graphql-loader#gp/refresh:
   version "1.0.2"
   resolved "https://codeload.github.com/gpoitch/graphql-loader/tar.gz/42f0f990a6132ccd5e284d0e6cfeade12728dba2"
   dependencies:


### PR DESCRIPTION
Added so we can add global query constraints, like with `setSite`, but more generic.